### PR TITLE
Update juniper_junos_show_ethernet-switching_table.textfsm

### DIFF
--- a/ntc_templates/templates/juniper_junos_show_ethernet-switching_table.textfsm
+++ b/ntc_templates/templates/juniper_junos_show_ethernet-switching_table.textfsm
@@ -11,7 +11,7 @@ Start
   ^Routing\sinstance\s:\sdefault-switch$$
   ^\s+Vlan\s+MAC\s+MAC\s+Age\s+Logical\s*\S*\s*\S*\s*$$
   ^\s+name\s+address\s+flags\s+interface\s*\S*\s*\S*\s*$$
-  ^\s+Vlan${VLAN}\s+${MAC_ADDRESS}\s+${MAC_FLAG}\s+${AGE}\s+${LOGICAL_INTERFACE}\s*\S*\s*\S* -> Record
+  ^\s+${VLAN}\s+${MAC_ADDRESS}\s+${MAC_FLAG}\s+${AGE}\s+${LOGICAL_INTERFACE}\s*\S*\s*\S* -> Record
   ^\s*$$
   ^{master:\d+}
   ^. -> Error


### PR DESCRIPTION
Replacement for 14th line - Template is pretty good, but this line doesn't match real pattern. 
Tested on Junos version 14.1X53-D47.6, hardware - qfx3500s

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
Juniper-JunOS  14.1X53-D47.6-show ethernet-switching table

##### SUMMARY
Template is pretty good, but this line doesn't match real pattern. 

SAMPLE OUTPUT that cannot be parsed with current template but can be parsed with my fix:
"""
MAC flags (S - static MAC, D - dynamic MAC, L - locally learned, P - Persistent static
           SE - statistics enabled, NM - non configured MAC, R - remote PE MAC, O - ovsdb MAC)


Ethernet switching table : 2 entries, 2 learned
Routing instance : default-switch
    Vlan                MAC                 MAC         Age    Logical
    name                address             flags              interface
    BD-903691           3c:8c:93:50:dc:c0   D             -   ae2.0
    BD-903691           52:54:00:f5:30:2b   D             -   ae2.0

MAC flags (S - static MAC, D - dynamic MAC, L - locally learned, P - Persistent static
           SE - statistics enabled, NM - non configured MAC, R - remote PE MAC, O - ovsdb MAC)


Ethernet switching table : 9 entries, 9 learned
Routing instance : default-switch
    Vlan                MAC                 MAC         Age    Logical
    name                address             flags              interface
    Vlan3117            00:00:5e:00:dd:dd   D             -   ae2.0
    Vlan3117            00:0c:29:07:f6:65   D             -   ae2.0
    Vlan3117            00:0c:29:84:d2:f8   D             -   xe-0/0/3.0
    Vlan3117            00:0c:29:8e:7e:a1   D             -   xe-0/0/2.0
    Vlan3117            00:0c:29:93:49:03   D             -   ae2.0
    Vlan3117            00:0c:29:e8:66:21   D             -   xe-0/0/3.0
    Vlan3117            3c:8c:93:50:dc:00   D             -   ae2.0
    Vlan3117            3c:8c:93:50:dc:c0   D             -   ae2.0
    Vlan3117            88:e6:4b:af:51:00   D             -   ae2.0

MAC flags (S - static MAC, D - dynamic MAC, L - locally learned, P - Persistent static
           SE - statistics enabled, NM - non configured MAC, R - remote PE MAC, O - ovsdb MAC)


Ethernet switching table : 45 entries, 45 learned
Routing instance : default-switch
    Vlan                MAC                 MAC         Age    Logical
    name                address             flags              interface
    v290                00:00:5e:00:dd:dd   D             -   ae2.0
    v290                00:50:56:b8:03:2d   D             -   xe-0/0/2.0
    v290                00:50:56:b8:03:6d   D             -   ae2.0
    v290                00:50:56:b8:05:df   D             -   xe-0/0/1.0
    v290                00:50:56:b8:08:d8   D             -   xe-0/0/2.0
    v290                00:50:56:b8:1c:58   D             -   xe-0/0/1.0
    v290                00:50:56:b8:20:56   D             -   xe-0/0/2.0
    v290                00:50:56:b8:26:06   D             -   xe-0/0/3.0
    v290                00:50:56:b8:28:88   D             -   xe-0/0/2.0
    v290                00:50:56:b8:29:50   D             -   ae2.0
    v290                00:50:56:b8:32:96   D             -   xe-0/0/2.0
    v290                00:50:56:b8:39:74   D             -   ae2.0
    v290                00:50:56:b8:3c:7b   D             -   xe-0/0/2.0
    v290                00:50:56:b8:47:ac   D             -   ae2.0
    v290                00:50:56:b8:48:ac   D             -   xe-0/0/1.0
    v290                00:50:56:b8:4b:94   D             -   xe-0/0/1.0
    v290                00:50:56:b8:57:b1   D             -   xe-0/0/2.0
    v290                00:50:56:b8:58:85   D             -   xe-0/0/2.0
    v290                00:50:56:b8:5b:87   D             -   xe-0/0/2.0
    v290                00:50:56:b8:60:e2   D             -   xe-0/0/2.0
    v290                00:50:56:b8:63:ee   D             -   xe-0/0/2.0
    v290                00:50:56:b8:75:07   D             -   ae2.0
    v290                00:50:56:b8:79:35   D             -   ae2.0
    v290                00:50:56:b8:7b:4a   D             -   xe-0/0/1.0
    v290                00:50:56:b8:7e:61   D             -   xe-0/0/2.0
    v290                00:50:56:b8:8a:2a   D             -   ae2.0
    v290                00:50:56:b8:91:b5   D             -   ae2.0
    v290                00:50:56:b8:96:ae   D             -   xe-0/0/3.0
    v290                00:50:56:b8:98:ec   D             -   xe-0/0/3.0
    v290                00:50:56:b8:9b:c0   D             -   xe-0/0/3.0
    v290                00:50:56:b8:a5:a0   D             -   ae2.0
    v290                00:50:56:b8:ba:58   D             -   xe-0/0/1.0
    v290                00:50:56:b8:bf:72   D             -   ae2.0
    v290                00:50:56:b8:c3:1c   D             -   ae2.0
    v290                00:50:56:b8:d1:28   D             -   xe-0/0/3.0
    v290                00:50:56:b8:d9:d7   D             -   xe-0/0/2.0
    v290                00:50:56:b8:dd:b7   D             -   xe-0/0/1.0
    v290                00:50:56:b8:e4:f1   D             -   xe-0/0/2.0
    v290                00:50:56:b8:e9:ee   D             -   xe-0/0/1.0
    v290                00:50:56:b8:f2:e4   D             -   ae2.0
    v290                00:50:56:b8:f6:de   D             -   xe-0/0/1.0
    v290                00:50:56:b8:fb:a5   D             -   xe-0/0/2.0
    v290                3c:8c:93:50:dc:00   D             -   ae2.0
    v290                3c:8c:93:50:dc:c0   D             -   ae2.0
    v290                88:e6:4b:af:51:00   D             -   ae2.0
"""

```

```
